### PR TITLE
Fix the case where no elements have been selected

### DIFF
--- a/ImageSelect.jquery.js
+++ b/ImageSelect.jquery.js
@@ -164,7 +164,9 @@
                     }
                 });
               });
-            $this.trigger('chosen:hiding_dropdown');
+            this.each(function(input_field) {
+              $(this).trigger('chosen:hiding_dropdown');
+            });
             return ret;
         }
       });

--- a/ImageSelect.jquery.js
+++ b/ImageSelect.jquery.js
@@ -164,7 +164,7 @@
                     }
                 });
               });
-            this.each(function(input_field) {
+            this.each(function() {
               $(this).trigger('chosen:hiding_dropdown');
             });
             return ret;


### PR DESCRIPTION
Suppose your code looks like this:

    $('select.user-picker').chosen({});

If the selector matches no elements, then the `chosen()` function still gets run. The value for `$this` (_not_ `$(this)`) never gets set, but then is used.