### PR TITLE
Images during search

### DIFF
--- a/ImageSelect.jquery.js
+++ b/ImageSelect.jquery.js
@@ -173,7 +173,7 @@
                     }
                 });
               });
-            this.each(function(input_field) {
+            this.each(function() {
               $(this).trigger('chosen:hiding_dropdown');
             });
             return ret;

--- a/ImageSelect.jquery.js
+++ b/ImageSelect.jquery.js
@@ -164,7 +164,9 @@
                     }
                 });
               });
-            $this.trigger('chosen:hiding_dropdown');
+            this.each(function(input_field) {
+              $(this).trigger('chosen:hiding_dropdown');
+            });
             return ret;
         }
       });

--- a/ImageSelect.jquery.js
+++ b/ImageSelect.jquery.js
@@ -67,6 +67,9 @@
                         }
                     }
 
+                    $this.on('chosen:filter', function(){
+                      $this.trigger('chosen:showing_dropdown');
+                    });
                });
             });
 
@@ -155,6 +158,12 @@
                     for(var i = 0; i < lis.length; i++){
                         var li = lis[i];
                         var option = options[i];
+
+                        var idx = $(li).attr('data-option-array-index');
+                        if (idx){
+                           option = chosen.form_field.options[chosen.results_data[idx].options_index];
+                        }
+
                         var img_src = $(option).attr('data-img-src');
 
                         if(img_src != undefined){


### PR DESCRIPTION
This patch allows the images to be show during find-as-you-type filtering.

However, it requires the `chosen:filter` event to be fired from Chosen, which is in a PR here: https://github.com/harvesthq/chosen/pull/2373