### PR TITLE
Remove Codemirror from dependencies and provide a code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,23 @@ We couldn't find any scripts that had this full functionality, so we developed i
 - Install dependencies, `bower install`
 - Browse to `index.html` or `example.html`
 
+## Usage
+
+You only need to add a `data-img-src` attribute to your `<option>` tag.
+```HTML
+<select class="my-select">
+  <option data-img-src="img/adnan.png">Adnan Sagar</option> 
+  <option data-img-src="img/rena.png">Rena Cugelman</option> 
+  <option data-img-src="img/tavis.png">Tavis Lochhead</option> 
+  <option data-img-src="img/brian.png" selected="selected">Brain Cugelman</option> 
+</select>
+```
+Then call Chosen as you would with the options you need.
+```JAVASCRIPT
+$(".my-select").chosen();
+```
+
+
 # Change Log
 All notable changes to this project will be documented in this section.
 

--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,9 @@
   ],
   "dependencies": {
     "jquery": "*",
-    "codemirror": "*",
     "chosen": "*"
+  },
+  devDependencies: {
+    "codemirror": "*"
   }
 }


### PR DESCRIPTION
This commit moves the Codemirror dependency to the development dependencies