### PR TITLE
Do not trigger chosen event when `chosen` is not available (eg on mob…

### DIFF
--- a/src/ImageSelect.jquery.js
+++ b/src/ImageSelect.jquery.js
@@ -178,7 +178,9 @@ $.fn.extend({
         })
 
         // Finally, trigger hiding_dropdown on all select elements
-        $this.trigger('chosen:hiding_dropdown',{chosen:chosen})
+        if(typeof chosen != 'undefined') {
+          $this.trigger('chosen:hiding_dropdown',{chosen:chosen})
+        }
     })
  }
 })


### PR DESCRIPTION
Fixes #33 — error when Chosen is not enabled (appears to be on mobile)